### PR TITLE
Add some features to streamline user experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,5 +53,11 @@ The flag can be adjusted, beware that when you put a high number, the applicatio
 
 Use the `help` flag to see the default value.
 
+## Install bash/zsh/fish completion
 
+```bash
+COMP_INSTALL=1 s3-recursive-acl
+```
+
+See [posener/complete/README.md](https://github.com/posener/complete/blob/master/README.md) for more details.
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/aws/aws-sdk-go v1.12.36
 	github.com/go-ini/ini v1.32.0 // indirect
 	github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8 // indirect
+	github.com/posener/complete/v2 v2.0.1-alpha.13
 	github.com/smartystreets/goconvey v1.6.4 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e // indirect


### PR DESCRIPTION
- Don't require `--region` flag when either of `AWS_REGION` or 
  `AWS_DEFAULT_REGION` is set as env var (the former takes precedence)
- Enable SDK support for the shared configuration file
  (`AWS_SDK_LOAD_CONFIG=1`) if it is not set while
  `AWS_SHARED_CREDENTIALS_FILE` env var is set
- Add `--profile` cmdline flag to set `AWS_PROFILE` env var automatically
- Add command line completion support